### PR TITLE
Moog filter updates

### DIFF
--- a/filter_moog_f32.cpp
+++ b/filter_moog_f32.cpp
@@ -27,18 +27,26 @@
 #include "filter_moog_f32.h"
 
 
+__inline__ float tanh_fast(float x)
+{
+  // rational tanh aproximation
+  float x2 = x * x;
+  float a = x * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
+  float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
+  return a / b;
+}
 
 #if defined(KINETISK)
 
 void AudioFilterMoog_F32::update_fixed(const float *in,float *lp)
 {
 	for (int i = 0; i < 2*AUDIO_BLOCK_SAMPLES; i++) {
-		float cs = tanhf(in[i/2] * driv);
-		y_a = y_a + g * (tanhf(cs - q * ((y_d_1 + y_d)/2) - tanhf(y_a)));
-		y_b = y_b + g * (tanhf(y_a) - tanhf(y_b));
-		y_c = y_c + g * (tanhf(y_b) - tanhf(y_c));
+		float cs = tanh_fast(in[i/2] * driv);
+		y_a = y_a + g * (tanh_fast(cs - q * ((y_d_1 + y_d)/2) - tanh_fast(y_a)));
+		y_b = y_b + g * (tanh_fast(y_a) - tanh_fast(y_b));
+		y_c = y_c + g * (tanh_fast(y_b) - tanh_fast(y_c));
 		y_d_1 = y_d;
-		y_d = y_d + g * (tanhf(y_c) - tanhf(y_d));
+		y_d = y_d + g * (tanh_fast(y_c) - tanh_fast(y_d));
 		lp[i/2]  = y_d;
 	}
 }
@@ -50,12 +58,12 @@ void AudioFilterMoog_F32::update_variable(const float *in,const float *ctl, floa
 		float nf=basef*(exp2f(ctl[0/over]*oct));
 		frequency(nf,false);
 	for (int i = 0; i < 2*AUDIO_BLOCK_SAMPLES; i++) {
-		float cs = tanhf(in[i/over] * driv);
-		y_a = y_a + g * (tanhf(cs - q * ((y_d_1 + y_d)/2) - tanhf(y_a)));
-		y_b = y_b + g * (tanhf(y_a) - tanhf(y_b));
-		y_c = y_c + g * (tanhf(y_b) - tanhf(y_c));
+		float cs = tanh_fast(in[i/over] * driv);
+		y_a = y_a + g * (tanh_fast(cs - q * ((y_d_1 + y_d)/2) - tanh_fast(y_a)));
+		y_b = y_b + g * (tanh_fast(y_a) - tanh_fast(y_b));
+		y_c = y_c + g * (tanh_fast(y_b) - tanh_fast(y_c));
 		y_d_1 = y_d;
-		y_d = y_d + g * (tanhf(y_c) - tanhf(y_d));
+		y_d = y_d + g * (tanh_fast(y_c) - tanh_fast(y_d));
 		lp[i/over]  = y_d;
 	}
 }

--- a/filter_moog_f32.h
+++ b/filter_moog_f32.h
@@ -28,7 +28,7 @@
 #define filter_moog_f32_h_
 
 #include "Arduino.h"
-#include "AudioStream_f32.h"
+#include "AudioStream_F32.h"
 #include "utility/dspinst.h"
 #include "arm_math.h"
 

--- a/filter_moog_f32.h
+++ b/filter_moog_f32.h
@@ -52,7 +52,7 @@ public:
 	frequency(1000);
 	resonance(1);
 	drive(1);
-	octave(1);
+	octaveControl(1);
 	y_a = 0;
 	y_b = 0;
 	y_c = 0;
@@ -72,7 +72,7 @@ public:
 		else if (qi > 5.0) qi = 5.0;
 		q=qi;
 	}
-	void octave(float n) {
+	void octaveControl(float n) {
 		if (n < 0.0) n = 0.0;
 		else if (n > 6.9999) n = 6.9999;
 		oct=n;

--- a/filter_moog_f32.h
+++ b/filter_moog_f32.h
@@ -60,12 +60,12 @@ public:
 	y_d_1 = 0;
 	}
 	void frequency(float freq,bool setf=true) {
+		if(setf)
+			basef=freq;
 		if (freq < 20.0) freq = 20.0;
 		else if (freq > AUDIO_SAMPLE_RATE_EXACT/2.5) freq = AUDIO_SAMPLE_RATE_EXACT/2.5;
 	    g = 1 - expf(-2 * tanf(2 * M_PI * freq/(2 * AUDIO_SAMPLE_RATE_EXACT)));
 //		Serial.println(freq);
-		if(setf)
-			basef=freq;
 	}
 	void resonance(float qi) {
 		if (qi < 0.7) qi = 0.7;


### PR DESCRIPTION
Some small but useful updates to the Moog Filter:

- Replaced `tanhf` invocations by a fast rational approximation. Otherwise a single moog filter would use up almost all CPU cycles of Teensy 3.5. Question is, if this is the case for other builds, or if I just got bad configuration. Still, hundreds of cycles sound feasable for `tanhf` even with FPU. Results may vary, but precision should be almost in range of 16bit integer audio, so there shouldn't be a dramatic audible impact.
- Remove base frequency limits. Limits are enforced after control is applied. Otherwise setting the base frequency would not allow to attenuate the control in signal, thus the filter could'nt be fully closed by manual frequency setting.
- Renamed `octave()` to `octaveControl` for drop-in replacement of Teensy Audio's State Variable Filter.
- Corrected case typo (Only build on Windows otherwise)